### PR TITLE
Fix jar download url

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,7 @@ end
 version = node['jolokia-jvm-agent']['version']
 
 remote_file "#{install_dir}/jolokia-jvm-#{version}-agent.jar" do
-  source "http://labs.consol.de/maven/repository/org/jolokia/jolokia-jvm/#{version}/jolokia-jvm-#{version}-agent.jar"
+  source "https://repo1.maven.org/maven2/org/jolokia/jolokia-jvm/#{version}/jolokia-jvm-#{version}-agent.jar"
   owner 'root'
   group 'root'
   mode '0644'


### PR DESCRIPTION
ダウンロードURLが変わったようなので修正。

以前のURL

```
wget  http://labs.consol.de/maven/repository/org/jolokia/jolokia-jvm/1.2.3/jolokia-jvm-1.2.3-agent.jar
--2015-06-15 16:06:13--  http://labs.consol.de/maven/repository/org/jolokia/jolokia-jvm/1.2.3/jolokia-jvm-1.2.3-agent.jar
Resolving labs.consol.de... 94.185.89.33, 2a03:3680:0:2::21
Connecting to labs.consol.de|94.185.89.33|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://labs.consol.de/maven/repository/org/jolokia/jolokia-jvm/1.2.3/jolokia-jvm-1.2.3-agent.jar [following]
--2015-06-15 16:06:14--  https://labs.consol.de/maven/repository/org/jolokia/jolokia-jvm/1.2.3/jolokia-jvm-1.2.3-agent.jar
Connecting to labs.consol.de|94.185.89.33|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2015-06-15 16:06:15 ERROR 404: Not Found.
```

修正後

```
wget  https://repo1.maven.org/maven2/org/jolokia/jolokia-jvm/1.2.3/jolokia-jvm-1.2.3-agent.jar
--2015-06-15 16:07:18--  https://repo1.maven.org/maven2/org/jolokia/jolokia-jvm/1.2.3/jolokia-jvm-1.2.3-agent.jar
Resolving repo1.maven.org... 199.27.79.209
Connecting to repo1.maven.org|199.27.79.209|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 395172 (386K) [application/java-archive]
Saving to: 'jolokia-jvm-1.2.3-agent.jar'

jolokia-jvm-1.2.3-agent.jar                       100%[===============================================================================================================>] 385.91K   585KB/s   in 0.7s

2015-06-15 16:07:19 (585 KB/s) - 'jolokia-jvm-1.2.3-agent.jar' saved [395172/395172]
```
